### PR TITLE
Mjc action update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,11 @@ jobs:
         git add .
         git commit -m "Update news main.csv"
         git push
+  
+  getkeywords:
+    needs: updatecsv
+    runs-on: ubuntu-latest
+    steps:
     - name: Run OPENAI Python script
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -59,7 +64,7 @@ jobs:
         git push
         
   deploy:
-    needs: updatecsv
+    needs: getkeywords
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,18 @@ jobs:
     needs: updatecsv
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pandas newsapi openai
     - name: Run OPENAI Python script
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
I've split the tasks that get the headlines and the tasks that get the keywords into two, just to make sure that we're not seeing a concurrency issue where the keywords job is running before the news job has finished